### PR TITLE
build: remove vue and vuetify from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
   "author": "John Leider <john@vuetifyjs.com>",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": "^9.23.0",
-    "vue": "^3.5.13",
-    "vuetify": "^3.7.19"
+    "eslint": "^9.23.0"
   },
   "dependencies": {
     "@eslint/js": "^9.23.0",


### PR DESCRIPTION
The removal of vue and vuetify from peerDependencies simplifies the package's dependency requirements, as they are no longer necessary for the core functionality (vue plugin even has support for vue 2, vuetify is not directly used in eslint setup)