### PR TITLE
Fix prerelease issues

### DIFF
--- a/src/configs/pnpm.ts
+++ b/src/configs/pnpm.ts
@@ -1,6 +1,8 @@
 import type { TypedFlatConfigItem } from '../types'
-
+import { hasFile } from '../utils'
 import { jsoncParser, pnpmPlugin, yamlParser } from '../vendors'
+
+const hasWorkspace = hasFile('pnpm-workspace.yaml') || hasFile('pnpm-workspace.yml')
 
 export function pnpm (): TypedFlatConfigItem[] {
   return [
@@ -11,7 +13,7 @@ export function pnpm (): TypedFlatConfigItem[] {
       name: 'vuetify/pnpm/package-json',
       plugins: { pnpm: pnpmPlugin },
       rules: {
-        'pnpm/json-prefer-workspace-settings': 'error',
+        'pnpm/json-prefer-workspace-settings': hasWorkspace ? 'error' : 'off',
         'pnpm/json-valid-catalog': 'error',
       },
     },

--- a/src/utils/autoimports.ts
+++ b/src/utils/autoimports.ts
@@ -24,7 +24,7 @@ export function loadAutoImports (options: Options['autoimports'] = true): TypedF
     if (!autoImportModuleURL) {
       return {}
     }
-    return compat.extends(autoImportModuleURL) as TypedFlatConfigItem
+    return compat.extends(autoImportModuleURL)[0] ?? {}
   } catch {
     return {}
   }


### PR DESCRIPTION
After prerelease testing in ecosystem, 2 errors were spotted:
1. autoimports resolver resolves array of config, while we need only 1st (and only)
2. pnpm/json-prefer-workspace-settings breaks linting if pnpm-workspace.yml wasn't in a repo