### PR TITLE
fix: point types field to emitted declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "./cli": "./dist/cli.mjs",
     "./package.json": "./package.json"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

The published `eslint-config-vuetify@4.7.0` package declares `types: "./dist/index.d.ts"`, but the package tarball does not include that file. The current ESM build emits `dist/index.d.mts`, which is also what appears in the published tarball.

This PR updates the package `types` field to point to the emitted declaration file.

## Validation

- `npm pack eslint-config-vuetify@4.7.0 --dry-run --json` confirms `dist/index.d.mts` is present and `dist/index.d.ts` is absent in the published package.
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build`
- `npm pack --dry-run --json` confirms the rebuilt package includes `dist/index.d.mts`.
- `node -e "const p=require('./package.json'); if (p.types !== './dist/index.d.mts') throw new Error(p.types); console.log(JSON.stringify({types:p.types, exportDefault:p.exports['.']}))"`
- `git diff --check`

Note: `pnpm test` was also attempted after building. It resolved the package entry, but the playground lint tests fail on this Windows environment because `new URL('..', import.meta.url).pathname` produces a `/C:/...` cwd, so ESLint cannot find the existing `playground/App.*` files. The files exist locally, and this appears unrelated to the package `types` metadata change.